### PR TITLE
feat: manual link saving MVP (modal, thumbnails, optional OG+Supabase)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,7 +1,7 @@
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { StatusBar } from 'react-native';
 import { ThemeProvider, useAppTheme } from './src/theme/ThemeProvider';
-import SavedContent from './src/components/SavedContent';
+import SavedScreen from './src/screens/SavedScreen';
 
 const ThemedStatusBar = () => {
   const { isDarkMode } = useAppTheme();
@@ -13,7 +13,7 @@ export default function App() {
     <SafeAreaProvider>
       <ThemeProvider>
         <ThemedStatusBar />
-        <SavedContent />
+        <SavedScreen />
       </ThemeProvider>
     </SafeAreaProvider>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,10 @@
       "name": "connect-your-saves-mobile",
       "version": "1.0.0",
       "dependencies": {
+        "@react-native-async-storage/async-storage": "^2.2.0",
+        "@supabase/supabase-js": "^2.54.0",
         "expo": "~53.0.20",
+        "expo-clipboard": "^7.1.5",
         "expo-linear-gradient": "~14.1.5",
         "expo-status-bar": "~2.2.3",
         "moti": "^0.30.0",
@@ -2364,6 +2367,18 @@
         "node": ">=14"
       }
     },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.2.0.tgz",
+      "integrity": "sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==",
+      "license": "MIT",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.65 <1.0"
+      }
+    },
     "node_modules/@react-native/assets-registry": {
       "version": "0.79.5",
       "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.79.5.tgz",
@@ -2664,6 +2679,80 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.71.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.71.1.tgz",
+      "integrity": "sha512-mMIQHBRc+SKpZFRB2qtupuzulaUhFYupNyxqDj5Jp/LyPvcWvjaJzZzObv6URtL/O6lPxkanASnotGtNpS3H2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.5.tgz",
+      "integrity": "sha512-v5GSqb9zbosquTo6gBwIiq7W9eQ7rE5QazsK/ezNiQXdCbY+bH8D9qEaBIkhVvX4ZRW5rP03gEfw5yw9tiq4EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "1.19.4",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.19.4.tgz",
+      "integrity": "sha512-O4soKqKtZIW3olqmbXXbKugUtByD2jPa8kL2m2c1oozAO11uCcGrRhkZL0kVxjBLrXHE0mdSkFsMj7jDSfyNpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.15.0.tgz",
+      "integrity": "sha512-SEIWApsxyoAe68WU2/5PCCuBwa11LL4Bb8K3r2FHCt3ROpaTthmDiWEhnLMGayP05N4QeYrMk0kyTZOwid/Hjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.13",
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.10.4",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.10.4.tgz",
+      "integrity": "sha512-cvL02GarJVFcNoWe36VBybQqTVRq6wQSOCvTS64C+eyuxOruFIm1utZAY0xi2qKtHJO3EjKaj8iWJKySusDmAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.54.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.54.0.tgz",
+      "integrity": "sha512-DLw83YwBfAaFiL3oWV26+sHRdeCGtxmIKccjh/Pndze3BWM4fZghzYKhk3ElOQU8Bluq4AkkCJ5bM5Szl/sfRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.71.1",
+        "@supabase/functions-js": "2.4.5",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.19.4",
+        "@supabase/realtime-js": "2.15.0",
+        "@supabase/storage-js": "^2.10.4"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2747,6 +2836,12 @@
         "undici-types": "~7.10.0"
       }
     },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.0.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.14.tgz",
@@ -2762,6 +2857,15 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
@@ -4065,6 +4169,17 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-clipboard": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/expo-clipboard/-/expo-clipboard-7.1.5.tgz",
+      "integrity": "sha512-TCANUGOxouoJXxKBW5ASJl2WlmQLGpuZGemDCL2fO5ZMl57DGTypUmagb0CVUFxDl0yAtFIcESd78UsF9o64aw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/expo-constants": {
       "version": "17.1.7",
       "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-17.1.7.tgz",
@@ -4658,6 +4773,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-wsl": {
@@ -5397,6 +5521,18 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
       "license": "MIT"
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -7900,6 +8036,12 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -8125,6 +8267,16 @@
       "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
       "license": "MIT"
     },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/whatwg-url-without-unicode": {
       "version": "8.0.0-3",
       "resolved": "https://registry.npmjs.org/whatwg-url-without-unicode/-/whatwg-url-without-unicode-8.0.0-3.tgz",
@@ -8138,6 +8290,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/whatwg-url/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -9,13 +9,16 @@
     "web": "expo start --web"
   },
   "dependencies": {
+    "@react-native-async-storage/async-storage": "^2.2.0",
+    "@supabase/supabase-js": "^2.54.0",
     "expo": "~53.0.20",
+    "expo-clipboard": "^7.1.5",
+    "expo-linear-gradient": "~14.1.5",
     "expo-status-bar": "~2.2.3",
     "moti": "^0.30.0",
     "react": "19.0.0",
     "react-native": "0.79.5",
-    "react-native-linear-gradient": "^2.8.3",
-    "expo-linear-gradient": "~14.1.5"
+    "react-native-linear-gradient": "^2.8.3"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/src/components/AddLinkModal.tsx
+++ b/src/components/AddLinkModal.tsx
@@ -1,0 +1,127 @@
+import React, { useState } from 'react';
+import {
+  Modal,
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  StyleSheet,
+} from 'react-native';
+import { useAppTheme } from '@/theme/ThemeProvider';
+
+export type AddLinkData = {
+  url: string;
+  title?: string;
+  tags: string[];
+  notes?: string;
+};
+
+interface Props {
+  visible: boolean;
+  onClose: () => void;
+  onSave: (data: AddLinkData) => void;
+}
+
+const AddLinkModal: React.FC<Props> = ({ visible, onClose, onSave }) => {
+  const { theme } = useAppTheme();
+  const [url, setUrl] = useState('');
+  const [title, setTitle] = useState('');
+  const [tags, setTags] = useState('');
+  const [notes, setNotes] = useState('');
+
+  const handleSave = () => {
+    const trimmed = url.trim();
+    if (!trimmed) return;
+    const data: AddLinkData = {
+      url: trimmed,
+      title: title.trim() || undefined,
+      tags: tags
+        .split(',')
+        .map((t) => t.trim().toLowerCase())
+        .filter(Boolean),
+      notes: notes.trim() || undefined,
+    };
+    onSave(data);
+    setUrl('');
+    setTitle('');
+    setTags('');
+    setNotes('');
+  };
+
+  return (
+    <Modal transparent animationType="slide" visible={visible} onRequestClose={onClose}>
+      <View style={styles.overlay}>
+        <View style={[styles.container, { backgroundColor: theme.card }]}>\n          <Text style={[styles.label, { color: theme.text }]}>URL</Text>\n          <TextInput
+            style={[styles.input, { borderColor: theme.border, color: theme.text }]}
+            value={url}
+            onChangeText={setUrl}
+            placeholder="https://example.com"
+            placeholderTextColor="#999"
+            autoCapitalize="none"
+          />\n          <Text style={[styles.label, { color: theme.text }]}>Title</Text>\n          <TextInput
+            style={[styles.input, { borderColor: theme.border, color: theme.text }]}
+            value={title}
+            onChangeText={setTitle}
+            placeholder="Optional title"
+            placeholderTextColor="#999"
+          />\n          <Text style={[styles.label, { color: theme.text }]}>Tags (comma separated)</Text>\n          <TextInput
+            style={[styles.input, { borderColor: theme.border, color: theme.text }]}
+            value={tags}
+            onChangeText={setTags}
+            placeholder="tags"
+            placeholderTextColor="#999"
+            autoCapitalize="none"
+          />\n          <Text style={[styles.label, { color: theme.text }]}>Notes</Text>\n          <TextInput
+            style={[styles.input, styles.notes, { borderColor: theme.border, color: theme.text }]}
+            value={notes}
+            onChangeText={setNotes}
+            placeholder="Optional notes"
+            placeholderTextColor="#999"
+            multiline
+          />\n          <View style={styles.buttons}>\n            <TouchableOpacity style={[styles.button, { backgroundColor: theme.border }]} onPress={onClose}>\n              <Text style={{ color: theme.text }}>Cancel</Text>\n            </TouchableOpacity>\n            <TouchableOpacity style={[styles.button, { backgroundColor: theme.primary }]} onPress={handleSave}>\n              <Text style={{ color: '#fff' }}>Save link</Text>\n            </TouchableOpacity>\n          </View>\n        </View>
+      </View>
+    </Modal>
+  );
+};
+
+export default AddLinkModal;
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 20,
+  },
+  container: {
+    width: '100%',
+    borderRadius: 12,
+    padding: 20,
+  },
+  label: {
+    fontSize: 14,
+    marginBottom: 4,
+  },
+  input: {
+    borderWidth: 1,
+    borderRadius: 8,
+    padding: 8,
+    marginBottom: 12,
+  },
+  notes: {
+    height: 80,
+    textAlignVertical: 'top',
+  },
+  buttons: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    gap: 12,
+    marginTop: 8,
+  },
+  button: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 8,
+  },
+});

--- a/src/components/ui/SavedCard.tsx
+++ b/src/components/ui/SavedCard.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import {
+  View,
+  Text,
+  Image,
+  StyleSheet,
+  Pressable,
+  Linking,
+} from 'react-native';
+import * as Clipboard from 'expo-clipboard';
+import { SavedItem } from '@/types/saved';
+import { useAppTheme } from '@/theme/ThemeProvider';
+
+interface Props {
+  item: SavedItem;
+}
+
+const SavedCard: React.FC<Props> = ({ item }) => {
+  const { theme } = useAppTheme();
+
+  const handleOpen = () => Linking.openURL(item.url);
+  const handleCopy = () => Clipboard.setStringAsync(item.url);
+
+  return (
+    <Pressable
+      style={({ pressed }) => [
+        styles.card,
+        { backgroundColor: theme.card, transform: [{ scale: pressed ? 0.98 : 1 }] },
+      ]}
+    >
+      {item.image ? (
+        <Image source={{ uri: item.image }} style={styles.image} />
+      ) : (
+        <View style={[styles.image, { backgroundColor: theme.border }]} />
+      )}
+      <View style={styles.pills}>
+        <Text style={[styles.pill, { backgroundColor: theme.primary, color: '#fff' }]}>
+          {item.platform}
+        </Text>
+        <Text style={[styles.pill, { backgroundColor: theme.border, color: theme.text }]}>
+          {item.domain}
+        </Text>
+      </View>
+      <View style={styles.content}>
+        <Text style={[styles.title, { color: theme.text }]} numberOfLines={2}>
+          {item.title}
+        </Text>
+        <Text style={[styles.url, { color: theme.text }]} numberOfLines={1}>
+          {item.url}
+        </Text>
+        {item.tags.length > 0 && (
+          <Text style={[styles.tags, { color: theme.text }]} numberOfLines={1}>
+            {item.tags.join(', ')}
+          </Text>
+        )}
+        <View style={styles.actions}>
+          <Pressable onPress={handleOpen}>
+            <Text style={[styles.actionText, { color: theme.primary }]}>Open</Text>
+          </Pressable>
+          <Pressable onPress={handleCopy}>
+            <Text style={[styles.actionText, { color: theme.primary }]}>Copy URL</Text>
+          </Pressable>
+        </View>
+      </View>
+    </Pressable>
+  );
+};
+
+export default SavedCard;
+
+const styles = StyleSheet.create({
+  card: {
+    borderRadius: 20,
+    overflow: 'hidden',
+    marginBottom: 16,
+    elevation: 2,
+  },
+  image: {
+    width: '100%',
+    aspectRatio: 16 / 9,
+  },
+  pills: {
+    position: 'absolute',
+    top: 8,
+    left: 8,
+    flexDirection: 'row',
+    gap: 8,
+  },
+  pill: {
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: 6,
+    fontSize: 12,
+  },
+  content: {
+    padding: 12,
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  url: {
+    fontSize: 12,
+    marginTop: 4,
+  },
+  tags: {
+    fontSize: 12,
+    marginTop: 4,
+  },
+  actions: {
+    flexDirection: 'row',
+    marginTop: 8,
+    gap: 16,
+  },
+  actionText: {
+    fontSize: 14,
+    fontWeight: '500',
+  },
+});

--- a/src/lib/og.ts
+++ b/src/lib/og.ts
@@ -1,0 +1,22 @@
+const OG_ENDPOINT = process.env.EXPO_PUBLIC_OG_ENDPOINT;
+
+export type OgResult = {
+  ok?: boolean;
+  title?: string;
+  description?: string;
+  image?: string | null;
+  siteName?: string;
+  icon?: string | null;
+  url?: string;
+};
+
+export async function fetchOg(url: string): Promise<OgResult | null> {
+  if (!OG_ENDPOINT) return null;
+  try {
+    const resp = await fetch(`${OG_ENDPOINT}?url=${encodeURIComponent(url)}`);
+    if (!resp.ok) return null;
+    return await resp.json();
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/preview.ts
+++ b/src/lib/preview.ts
@@ -1,0 +1,44 @@
+export const detectPlatform = (
+  url: string,
+): 'instagram' | 'tiktok' | 'youtube' | 'twitter' | 'reddit' | 'web' => {
+  const u = url.toLowerCase();
+  if (u.includes('instagram.com')) return 'instagram';
+  if (u.includes('tiktok.com')) return 'tiktok';
+  if (u.includes('youtube.com') || u.includes('youtu.be')) return 'youtube';
+  if (u.includes('twitter.com') || u.includes('x.com')) return 'twitter';
+  if (u.includes('reddit.com')) return 'reddit';
+  return 'web';
+};
+
+export const domainFrom = (url: string): string => {
+  try {
+    return new URL(url).hostname.replace(/^www\./, '');
+  } catch {
+    return '';
+  }
+};
+
+export const isImageUrl = (url: string) =>
+  /\.(png|jpe?g|webp|gif)(\?.*)?$/i.test(url);
+
+export const getYouTubeId = (url: string): string | null => {
+  try {
+    const u = new URL(url);
+    if (u.hostname.includes('youtu.be')) return u.pathname.replace('/', '');
+    if (u.searchParams.get('v')) return u.searchParams.get('v');
+    const parts = u.pathname.split('/');
+    const i = parts.indexOf('shorts');
+    if (i >= 0 && parts[i + 1]) return parts[i + 1];
+    return null;
+  } catch {
+    return null;
+  }
+};
+
+export const fallbackFavicon = (domain: string) =>
+  domain ? `https://www.google.com/s2/favicons?sz=256&domain=${encodeURIComponent(domain)}` : null;
+
+export const youtubeThumb = (url: string) => {
+  const id = getYouTubeId(url);
+  return id ? `https://i.ytimg.com/vi/${id}/hqdefault.jpg` : null;
+};

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,0 +1,21 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { SavedItem } from '@/types/saved';
+
+const KEY = 'savedit:saved';
+
+export async function loadSaved(): Promise<SavedItem[]> {
+  try {
+    const raw = await AsyncStorage.getItem(KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+}
+
+export async function saveSaved(items: SavedItem[]): Promise<void> {
+  try {
+    await AsyncStorage.setItem(KEY, JSON.stringify(items));
+  } catch {
+    // ignore
+  }
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+const url = process.env.EXPO_PUBLIC_SUPABASE_URL;
+const anon = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;
+
+export const supabase = url && anon ? createClient(url, anon) : null;

--- a/src/screens/SavedScreen.tsx
+++ b/src/screens/SavedScreen.tsx
@@ -1,0 +1,171 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, Pressable, StyleSheet, FlatList } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useAppTheme } from '@/theme/ThemeProvider';
+import AddLinkModal, { AddLinkData } from '@/components/AddLinkModal';
+import { SavedItem } from '@/types/saved';
+import { loadSaved, saveSaved } from '@/lib/storage';
+import {
+  detectPlatform,
+  domainFrom,
+  isImageUrl,
+  youtubeThumb,
+  fallbackFavicon,
+} from '@/lib/preview';
+import { fetchOg } from '@/lib/og';
+import { supabase } from '@/lib/supabase';
+import SavedCard from '@/components/ui/SavedCard';
+
+const SavedScreen = () => {
+  const { theme } = useAppTheme();
+  const [items, setItems] = useState<SavedItem[]>([]);
+  const [modalVisible, setModalVisible] = useState(false);
+  const [cloudEmpty, setCloudEmpty] = useState(false);
+
+  useEffect(() => {
+    loadSaved().then(setItems);
+    if (supabase) {
+      (async () => {
+        const { data: userData } = await supabase.auth.getUser();
+        const user = userData?.user;
+        if (!user) return;
+        const { data } = await supabase.from('saved_items').select('*');
+        if (data && data.length) {
+          const mapped: SavedItem[] = data.map((d: any) => ({
+            id: d.id,
+            url: d.url,
+            title: d.title || d.url,
+            platform: d.platform,
+            tags: d.tags || [],
+            notes: d.notes || undefined,
+            addedAt: new Date(d.added_at).getTime(),
+            domain: d.domain || domainFrom(d.url),
+            image: null,
+          }));
+          setItems(mapped);
+          setCloudEmpty(false);
+        } else {
+          setCloudEmpty(true);
+        }
+      })();
+    }
+  }, []);
+
+  useEffect(() => {
+    saveSaved(items);
+  }, [items]);
+
+  const handleSave = async (data: AddLinkData) => {
+    const platform = detectPlatform(data.url);
+    const domain = domainFrom(data.url);
+    let image: string | null = null;
+    if (isImageUrl(data.url)) {
+      image = data.url;
+    } else if (platform === 'youtube') {
+      image = youtubeThumb(data.url);
+    } else {
+      const key = `savedit:og:${encodeURIComponent(data.url)}`;
+      const cached = await AsyncStorage.getItem(key);
+      if (cached) {
+        try {
+          image = JSON.parse(cached).image || null;
+        } catch {
+          image = null;
+        }
+      }
+      if (!image) {
+        const og = await fetchOg(data.url);
+        if (og) {
+          image = og.image || null;
+          await AsyncStorage.setItem(key, JSON.stringify(og));
+        }
+      }
+      if (!image) {
+        image = fallbackFavicon(domain);
+      }
+    }
+    const newItem: SavedItem = {
+      id: Date.now().toString(),
+      url: data.url,
+      title: data.title || data.url,
+      platform,
+      tags: data.tags,
+      notes: data.notes,
+      addedAt: Date.now(),
+      domain,
+      image,
+    };
+    setItems((prev) => [newItem, ...prev]);
+    setModalVisible(false);
+  };
+
+  const uploadCloud = async () => {
+    if (!supabase) return;
+    const { data: userData } = await supabase.auth.getUser();
+    const user = userData?.user;
+    if (!user) return;
+    await supabase.from('saved_items').insert(
+      items.map((i) => ({
+        url: i.url,
+        title: i.title,
+        platform: i.platform,
+        tags: i.tags,
+        notes: i.notes,
+        domain: i.domain,
+        added_at: new Date(i.addedAt).toISOString(),
+      })),
+    );
+    setCloudEmpty(false);
+  };
+
+  return (
+    <View style={[styles.container, { backgroundColor: theme.background }]}>\n      <Pressable
+        style={[styles.hero, { backgroundColor: theme.card }]}
+        onPress={() => setModalVisible(true)}\n      >\n        <Text style={[styles.heroText, { color: theme.primary }]}>+ Save a link</Text>\n      </Pressable>
+      <FlatList
+        data={items}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => <SavedCard item={item} />}
+        contentContainerStyle={{ paddingTop: 16 }}
+      />
+      {supabase && cloudEmpty && items.length > 0 && (
+        <Pressable
+          onPress={uploadCloud}
+          style={[styles.upload, { backgroundColor: theme.card }]}
+        >
+          <Text style={{ color: theme.primary }}>Upload local → cloud</Text>
+        </Pressable>
+      )}
+      <AddLinkModal
+        visible={modalVisible}
+        onClose={() => setModalVisible(false)}
+        onSave={handleSave}
+      />
+    </View>
+  );
+};
+
+export default SavedScreen;
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+  },
+  hero: {
+    borderRadius: 20,
+    padding: 32,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  heroText: {
+    fontSize: 18,
+    fontWeight: '600',
+  },
+  upload: {
+    marginTop: 8,
+    padding: 12,
+    borderRadius: 12,
+    alignItems: 'center',
+  },
+});

--- a/src/types/saved.ts
+++ b/src/types/saved.ts
@@ -1,0 +1,19 @@
+export type Platform =
+  | 'instagram'
+  | 'tiktok'
+  | 'youtube'
+  | 'twitter'
+  | 'reddit'
+  | 'web';
+
+export type SavedItem = {
+  id: string;
+  url: string;
+  title: string;
+  platform: Platform;
+  tags: string[];
+  notes?: string;
+  addedAt: number;
+  domain: string;
+  image?: string | null;
+};


### PR DESCRIPTION
## Summary
- add Saved screen wired to AsyncStorage and optional Supabase sync
- introduce AddLinkModal for URL, title, tags, and notes
- implement thumbnail helpers with OG fetch and favicon fallback

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68964fdf1894832e9be6c71f1fa3f5d2